### PR TITLE
chore: add a prepublishOnly hook that tags our publishes in git

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+# Dependency directory
+# https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
+node_modules
+ios/RCTWebRTC.xcodeproj/xcuserdata
+ios/RCTWebRTC.xcodeproj/project.xcworkspace
+.DS_Store
+.idea
+android/build
+android/*.iml
+*.tgz
+scripts

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "url": "git+https://github.com/daily-co/react-native-webrtc.git"
   },
   "scripts": {
-    "prepublishOnly": "TAG_NAME=$(echo ${npm_package_name} | sed -E 's|^.+/||')-$(date -u +'%Y-%m-%d')-${npm_package_version} && git tag -a -m \"${npm_package_name} ${npm_package_version} published to npmjs\" ${TAG_NAME} HEAD && git push origin ${TAG_NAME}"
+    "tag": "scripts/tag",
+    "prepublishOnly": "npm run tag"
   },
   "nativePackage": true,
   "description": "Daily.co fork of WebRTC for React Native",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "git+https://github.com/daily-co/react-native-webrtc.git"
   },
+  "scripts": {
+    "prepublishOnly": "TAG_NAME=$(echo ${npm_package_name} | sed -E 's|^.+/||')-$(date -u +'%Y-%m-%d')-${npm_package_version} && git tag -a -m \"${npm_package_name} ${npm_package_version} published to npmjs\" ${TAG_NAME} HEAD && git push origin ${TAG_NAME}"
+  },
   "nativePackage": true,
   "description": "Daily.co fork of WebRTC for React Native",
   "homepage": "https://github.com/daily-co/react-native-webrtc",

--- a/scripts/tag
+++ b/scripts/tag
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+TAG_NAME=$(echo ${npm_package_name} | sed -E 's|^.+/||')-$(date -u +'%Y-%m-%d')-${npm_package_version} && \
+  git tag -a -m "${npm_package_name} ${npm_package_version} published to npmjs" ${TAG_NAME} HEAD && \
+  git push origin ${TAG_NAME}


### PR DESCRIPTION
This PR adds a `prepublishOnly` hook that tags git and pushes to GitHub when we `npm publish`.