### PR TITLE
A couple of iOS audio-handling improvements

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+Daily.m
+++ b/ios/RCTWebRTC/WebRTCModule+Daily.m
@@ -74,7 +74,11 @@ RCT_EXPORT_METHOD(setDailyAudioMode:(NSString *)audioMode) {
   config.mode = ([audioMode isEqualToString:AUDIO_MODE_VIDEO_CALL] ?
                  AVAudioSessionModeVideoChat :
                  AVAudioSessionModeVoiceChat);
-  config.categoryOptions = AVAudioSessionCategoryOptionAllowBluetooth;
+  // Ducking other apps' audio implicitly enables allowing mixing audio with
+  // other apps, which allows this app to stay alive in the backgrounnd during
+  // a call (assuming it has the voip background mode set).
+  config.categoryOptions = (AVAudioSessionCategoryOptionAllowBluetooth |
+                            AVAudioSessionCategoryOptionDuckOthers);
   
   NSError *error;
   [audioSession setConfiguration:config error:&error];

--- a/ios/RCTWebRTC/WebRTCModule+Daily.m
+++ b/ios/RCTWebRTC/WebRTCModule+Daily.m
@@ -77,8 +77,12 @@ RCT_EXPORT_METHOD(setDailyAudioMode:(NSString *)audioMode) {
   // Ducking other apps' audio implicitly enables allowing mixing audio with
   // other apps, which allows this app to stay alive in the backgrounnd during
   // a call (assuming it has the voip background mode set).
-  config.categoryOptions = (AVAudioSessionCategoryOptionAllowBluetooth |
-                            AVAudioSessionCategoryOptionDuckOthers);
+  AVAudioSessionCategoryOptions categoryOptions = (AVAudioSessionCategoryOptionAllowBluetooth |
+                                                   AVAudioSessionCategoryOptionDuckOthers);
+  if ([audioMode isEqualToString:AUDIO_MODE_VIDEO_CALL]) {
+    categoryOptions |= AVAudioSessionCategoryOptionDefaultToSpeaker;
+  }
+  config.categoryOptions = categoryOptions;
   
   NSError *error;
   [audioSession setConfiguration:config error:&error];


### PR DESCRIPTION
1. When other audio apps (podcasts, music) are playing, duck their audio while the call is ongoing rather than letting them stop the call audio. This allows the app to continue executing in the background if the voip background mode is used, since media is still playing.
2. More reliably default to the speaker (rather than the earpiece) when returning from an interrupting call.

Note: 2) was tested and works well with FaceTime and regular calls. There are still issues when recovering from a Skype call, which seems to leave the audio session in a mangled state