### PR TITLE
Comment out warning about not supplying video track to RTCView—it's v…

### DIFF
--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -337,7 +337,7 @@ RCT_CUSTOM_VIEW_PROPERTY(streamURL, NSString *, RTCVideoView) {
         NSArray *videoTracks = stream ? stream.videoTracks : @[];
         RTCVideoTrack *videoTrack = [videoTracks firstObject];
         if (!videoTrack) {
-            RCTLogWarn(@"No video stream for react tag: %@", streamReactTag);
+            // RCTLogWarn(@"No video stream for react tag: %@", streamReactTag);
         } else {
             dispatch_async(dispatch_get_main_queue(), ^{
                 view.videoTrack = videoTrack;


### PR DESCRIPTION
…alid to just supply an audio track, and valuable from a developer ergonomics standpoint to be able to do so. There is no equivalent warning on Android.

This is the lowest-risk intervention to avoid an unnecessary (and frequent) warning at the moment. In the future, we may want to tweak `DailyMediaView` to not use `RTCView` when no video is playing. I tried out that change and it seemed to work OK based on initial testing, but I'd want it to bake a bit longer. This will address the issue in the meantime.