### PR TITLE
Fixing the bug: audio stop working for other apps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Versions
+
+## 1.89.2-daily.4
+- Fixing the bug (Audio stop working for other apps): https://linear.app/dailyco/issue/ENG-2976/audio-stop-working-for-other-apps 

--- a/android/src/main/java/com/oney/WebRTCModule/DailyAudioManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/DailyAudioManager.java
@@ -75,10 +75,15 @@ public class DailyAudioManager implements AudioManager.OnAudioFocusChangeListene
 
             @Override
             public void onHostPause() {
+                Log.d(TAG, "onHostPause");
             }
 
             @Override
             public void onHostDestroy() {
+                Log.d(TAG, "onHostDestroy");
+                executor.execute(() -> {
+                    DailyAudioManager.this.setMode(Mode.IDLE);
+                });
             }
         });
         this.audioManager = (AudioManager) reactContext.getSystemService(Context.AUDIO_SERVICE);
@@ -190,6 +195,7 @@ public class DailyAudioManager implements AudioManager.OnAudioFocusChangeListene
     }
 
     private void abandonAudioFocus() {
+        Log.d(TAG, "abandonAudioFocus");
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             if (audioFocusRequest == null) {
                 Log.d(TAG, "abandonAudioFocus: expected audioFocusRequest to exist");
@@ -202,11 +208,11 @@ public class DailyAudioManager implements AudioManager.OnAudioFocusChangeListene
     }
 
     private void configureDevicesForCurrentMode() {
+        Log.d(TAG, "configureDevicesForCurrentMode => " + mode);
         if (mode == Mode.IDLE) {
             audioManager.setMode(AudioManager.MODE_NORMAL);
             audioManager.setSpeakerphoneOn(false);
             toggleBluetooth(false);
-            audioManager.setMicrophoneMute(true);
         } else {
             audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
             Set<DeviceType> availableDeviceTypes = getAvailableDeviceTypes();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daily-co/react-native-webrtc",
-  "version": "1.89.2-daily.3",
+  "version": "1.89.2-daily.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/daily-co/react-native-webrtc.git"


### PR DESCRIPTION
Fixing the bug: https://linear.app/dailyco/issue/ENG-2976/audio-stop-working-for-other-apps

When entering in the idle state, the microphone was been muted, make that unavailable to all the other apps. It has also been created a protection to release the audio focus in the case the app is close.

Steps to make sure It is working:
- Open our DailyPlayground app;
- Join a conference (open your mic and camera);
- Leave the conference;
- Open whatsapp;
- Try to record an audio at whatsapp;
- See that the audio has been sent with audio;