### PR TITLE
Fixing the type MediaTrackConstraints so the fields mandatory and opt…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -230,13 +230,13 @@ export interface MediaSources {
 }
 
 export interface MediaTrackConstraints {
-    mandatory: MandatoryMedia;
+    mandatory?: MandatoryMedia;
     width?: number;
     height?: number;
     frameRate?: number;
     facingMode?: 'user' | 'environment';
     deviceId?: string;
-    optional: MediaSources[];
+    optional?: MediaSources[];
 }
 
 export interface MediaStreamConstraints {


### PR DESCRIPTION
Fixing the type MediaTrackConstraints so the fields mandatory and optional are not longer required as obrigatory.

More details can be found here:
https://linear.app/dailyco/issue/ENG-3201/fixing-the-type-mediatrackconstraints-on-react-native-webrtc
