### PR TITLE
Support enumerateDevices, setAudioDevice, getAudioDevice and ondevicechange

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/DailyWebRTCDevicesManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/DailyWebRTCDevicesManager.java
@@ -1,0 +1,201 @@
+package com.oney.WebRTCModule;
+
+import android.content.Context;
+import android.media.AudioDeviceCallback;
+import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
+import android.util.Log;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+
+import org.webrtc.Camera1Enumerator;
+import org.webrtc.Camera2Enumerator;
+import org.webrtc.CameraEnumerator;
+
+import java.util.Arrays;
+
+public class DailyWebRTCDevicesManager {
+
+    static final String TAG = DailyWebRTCDevicesManager.class.getCanonicalName();
+    static final String ON_DEVICE_CHANGE_EVENT = "mediaDevicesOnDeviceChange";
+
+    public enum DeviceKind {
+        VIDEO_INPUT("videoinput"),
+        AUDIO("audio");
+
+        private String kind;
+
+        DeviceKind(String kind) {
+            this.kind = kind;
+        }
+
+        public String getKind() {
+            return this.kind;
+        }
+    }
+
+    public enum AudioDeviceType {
+        BLUETOOTH,
+        SPEAKERPHONE,
+        WIRED_OR_EARPIECE
+    }
+
+    private AudioDeviceCallback audioDeviceCallback = new AudioDeviceCallback() {
+        @Override
+        public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
+            DailyWebRTCDevicesManager.this.webRTCModule.sendEvent(ON_DEVICE_CHANGE_EVENT, null);
+        }
+
+        @Override
+        public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
+            DailyWebRTCDevicesManager.this.webRTCModule.sendEvent(ON_DEVICE_CHANGE_EVENT, null);
+        }
+    };
+
+    private final CameraEnumerator cameraEnumerator;
+    private AudioManager audioManager;
+    private ReactApplicationContext reactContext;
+    private final WebRTCModule webRTCModule;
+
+    public DailyWebRTCDevicesManager(WebRTCModule webRTCModule, ReactApplicationContext reactContext) {
+        this.webRTCModule = webRTCModule;
+        this.reactContext = reactContext;
+        this.audioManager = (AudioManager) reactContext.getSystemService(Context.AUDIO_SERVICE);
+        this.cameraEnumerator = this.createCameraEnumerator();
+    }
+
+    public void startMediaDevicesEventMonitor() {
+        this.audioManager.registerAudioDeviceCallback(audioDeviceCallback, null);
+    }
+
+    private CameraEnumerator createCameraEnumerator() {
+        boolean camera2supported = false;
+        try {
+            camera2supported = Camera2Enumerator.isSupported(this.reactContext);
+        } catch (Throwable tr) {
+            // Some devices will crash here with: Fatal Exception: java.lang.AssertionError: Supported FPS ranges cannot be null.
+            // Make sure we don't.
+            Log.w(TAG, "Error checking for Camera2 API support.", tr);
+        }
+        CameraEnumerator cameraEnumerator = null;
+        if (camera2supported) {
+            Log.d(TAG, "Creating video capturer using Camera2 API.");
+            cameraEnumerator = new Camera2Enumerator(this.reactContext);
+        } else {
+            Log.d(TAG, "Creating video capturer using Camera1 API.");
+            cameraEnumerator = new Camera1Enumerator(false);
+        }
+        return cameraEnumerator;
+    }
+
+    ReadableArray enumerateDevices() {
+        WritableArray devicesArray = Arguments.createArray();
+        this.fillVideoInputDevices(devicesArray);
+        this.fillAudioDevices(devicesArray);
+        return devicesArray;
+    }
+
+    private void fillVideoInputDevices(WritableArray enumerateDevicesArray) {
+        String[] devices = cameraEnumerator.getDeviceNames();
+        for (int i = 0; i < devices.length; ++i) {
+            String deviceName = devices[i];
+            boolean isFrontFacing;
+            try {
+                // This can throw an exception when using the Camera 1 API.
+                isFrontFacing = cameraEnumerator.isFrontFacing(deviceName);
+            } catch (Exception e) {
+                Log.e(TAG, "Failed to check the facing mode of camera");
+                continue;
+            }
+            String label = isFrontFacing ? "Front camera" : "Rear camera";
+            String deviceID = isFrontFacing ? "CAMERA_USER" : "CAMERA_ENVIRONMENT";
+            WritableMap params = this.createWritableMap(deviceID, label, DeviceKind.VIDEO_INPUT.getKind());
+            params.putString("facing", isFrontFacing ? "user" : "environment");
+            enumerateDevicesArray.pushMap(params);
+        }
+    }
+
+    private void fillAudioDevices(WritableArray enumerateDevicesArray) {
+        AudioDeviceInfo[] audioOutputDevices = this.audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
+
+        boolean isWiredHeadsetPlugged = Arrays.stream(audioOutputDevices).anyMatch(
+                device -> device.getType() == AudioDeviceInfo.TYPE_WIRED_HEADSET ||
+                        device.getType() == AudioDeviceInfo.TYPE_WIRED_HEADPHONES
+        );
+
+        WritableMap params = isWiredHeadsetPlugged ?
+                this.createWritableMap(AudioDeviceType.WIRED_OR_EARPIECE.toString(), "Wired headset", DeviceKind.AUDIO.getKind()) :
+                this.createWritableMap(AudioDeviceType.WIRED_OR_EARPIECE.toString(), "Phone earpiece", DeviceKind.AUDIO.getKind());
+        enumerateDevicesArray.pushMap(params);
+
+        //speaker
+        params = this.createWritableMap(AudioDeviceType.SPEAKERPHONE.toString(), "Speakerphone", DeviceKind.AUDIO.getKind());
+        enumerateDevicesArray.pushMap(params);
+
+        boolean isBluetoothHeadsetPlugged = Arrays.stream(audioOutputDevices).anyMatch(device -> device.getType() == AudioDeviceInfo.TYPE_BLUETOOTH_SCO);
+        if (isBluetoothHeadsetPlugged) {
+            params = this.createWritableMap(AudioDeviceType.BLUETOOTH.toString(), "Bluetooth", DeviceKind.AUDIO.getKind());
+            enumerateDevicesArray.pushMap(params);
+        }
+    }
+
+    private WritableMap createWritableMap(String deviceId, String label, String kind) {
+        WritableMap audioMap = Arguments.createMap();
+        audioMap.putString("deviceId", deviceId);
+        audioMap.putString("groupId", "");
+        audioMap.putString("label", label);
+        audioMap.putString("kind", kind);
+        return audioMap;
+    }
+
+    /**
+     * Changes selection of the currently active audio device.
+     */
+    public void setAudioDevice(String deviceId) {
+        Log.d(TAG, "setAudioDevice(audioDeviceType=" + deviceId + ")");
+        AudioDeviceType audioRoute = AudioDeviceType.valueOf(deviceId);
+        switch (audioRoute) {
+            case SPEAKERPHONE:
+                toggleBluetooth(false);
+                audioManager.setSpeakerphoneOn(true);
+                break;
+            //If we have a wired headset plugged, It is not possible we send the audio to the earpiece
+            case WIRED_OR_EARPIECE:
+                toggleBluetooth(false);
+                audioManager.setSpeakerphoneOn(false);
+                break;
+            case BLUETOOTH:
+                audioManager.setSpeakerphoneOn(false);
+                toggleBluetooth(true);
+                break;
+            default:
+                Log.e(TAG, "Invalid audio device selection");
+                break;
+        }
+    }
+
+    public String getAudioDevice() {
+        if (this.audioManager.isBluetoothScoOn() || this.audioManager.isBluetoothA2dpOn()) {
+            return AudioDeviceType.BLUETOOTH.toString();
+        } else if (this.audioManager.isSpeakerphoneOn()) {
+            return AudioDeviceType.SPEAKERPHONE.toString();
+        } else {
+            return AudioDeviceType.WIRED_OR_EARPIECE.toString();
+        }
+    }
+
+    private void toggleBluetooth(boolean on) {
+        if (on) {
+            audioManager.startBluetoothSco();
+            audioManager.setBluetoothScoOn(true);
+        } else {
+            audioManager.setBluetoothScoOn(false);
+            audioManager.stopBluetoothSco();
+        }
+    }
+
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ export type RTCIceConnectionState =
 
 export type RTCPeerConnectionState = 'new' | 'connecting' | 'connected' | 'disconnected' | 'failed' | 'closed';
 
-export type MediaDeviceKind = 'audioinput' | 'audiooutput' | 'videoinput';
+export type MediaDeviceKind = 'videoinput' | 'audio';
 
 export class MediaDeviceInfo {
     readonly deviceId: string;

--- a/ios/RCTWebRTC/WebRTCModule+DailyAudioMode.h
+++ b/ios/RCTWebRTC/WebRTCModule+DailyAudioMode.h
@@ -1,0 +1,22 @@
+//
+//  WebRTCModule+DevicesManager.m
+//  react-native-webrtc
+//
+//  Created by Filipi Fuchter on 01/04/22.
+//
+
+#import "WebRTCModule.h"
+
+// audio modes
+static NSString * _Nonnull const AUDIO_MODE_VIDEO_CALL = @"video";
+static NSString * _Nonnull const AUDIO_MODE_VOICE_CALL = @"voice";
+static NSString * _Nonnull const AUDIO_MODE_IDLE = @"idle";
+static NSString * _Nonnull const AUDIO_MODE_USER_SPECIFIED_ROUTE = @"user_specified";
+
+@interface WebRTCModule (DailyAudioMode)
+
+@property (nonatomic, strong) NSString *audioMode;
+
+- (void)setAudioMode:(nonnull NSString*)audioMode;
+
+@end

--- a/ios/RCTWebRTC/WebRTCModule+DailyAudioMode.m
+++ b/ios/RCTWebRTC/WebRTCModule+DailyAudioMode.m
@@ -1,0 +1,18 @@
+#import <objc/runtime.h>
+#import "WebRTCModule.h"
+#import "WebRTCModule+DailyAudioMode.h"
+
+@implementation WebRTCModule (DailyAudioMode)
+
+- (void)setAudioMode:(NSString *)audioMode {
+  objc_setAssociatedObject(self,
+                           @selector(audioMode),
+                           audioMode,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (NSString *)audioMode {
+  return  objc_getAssociatedObject(self, @selector(audioMode));
+}
+
+@end

--- a/ios/RCTWebRTC/WebRTCModule+DailyDevicesManager.h
+++ b/ios/RCTWebRTC/WebRTCModule+DailyDevicesManager.h
@@ -1,0 +1,26 @@
+//
+//  WebRTCModule+DevicesManager.m
+//  react-native-webrtc
+//
+//  Created by Filipi Fuchter on 01/04/22.
+//
+
+#import "WebRTCModule.h"
+
+// audio devices routes
+static NSString * _Nonnull const WIRED_OR_EARPIECE_DEVICE_ID = @"WIRED_OR_EARPIECE";
+static NSString * _Nonnull const SPEAKERPHONE_DEVICE_ID = @"SPEAKERPHONE";
+static NSString * _Nonnull const BLUETOOTH_DEVICE_ID = @"BLUETOOTH";
+
+@interface WebRTCModule (DailyDevicesManager)
+
+@property (nonatomic, strong) NSString *userSelectedDevice;
+
+- (BOOL)hasBluetoothDevice;
+- (BOOL)hasWiredHeadset;
+- (void)setAudioDevice:(nonnull NSString*)deviceId;
+- (void)configureAudioSession:(nonnull AVAudioSession *)audioSession
+              audioMode:(nonnull NSString *)mode
+              categoryOptions: (AVAudioSessionCategoryOptions) categoryOptions;
+
+@end

--- a/ios/RCTWebRTC/WebRTCModule+DailyDevicesManager.m
+++ b/ios/RCTWebRTC/WebRTCModule+DailyDevicesManager.m
@@ -1,0 +1,276 @@
+//
+//  WebRTCModule+DailyDevicesManager.m
+//  react-native-webrtc
+//
+//  Created by Filipi Fuchter on 08/03/22.
+//
+
+#import <objc/runtime.h>
+#import "WebRTCModule.h"
+#import "WebRTCModule+DailyDevicesManager.h"
+#import "WebRTCModule+DailyAudioMode.h"
+
+@implementation WebRTCModule (DailyDevicesManager)
+
+static NSString const *DEVICE_KIND_VIDEO_INPUT = @"videoinput";
+static NSString const *DEVICE_KIND_AUDIO = @"audio";
+
+- (void)setUserSelectedDevice:(NSString *)userSelectedDevice {
+  objc_setAssociatedObject(self,
+                           @selector(userSelectedDevice),
+                           userSelectedDevice,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (NSString *)userSelectedDevice {
+  return  objc_getAssociatedObject(self, @selector(userSelectedDevice));
+}
+
+RCT_EXPORT_METHOD(enumerateDevices:(RCTResponseSenderBlock)callback)
+{
+    NSLog(@"[Daily] enumerateDevice from DailyDevicesManager");
+    NSMutableArray *devices = [NSMutableArray array];
+    
+    [self fillVideoInputDevices:devices];
+    [self fillAudioDevices:devices];
+    
+    callback(@[devices]);
+}
+
+// Whenever any headphones plugged in, it becomes the default audio route even if there is also bluetooth device.
+// And it overwrites the handset(iPhone) option, which means you cannot change to the handset(iPhone).
+- (void)fillVideoInputDevices:(NSMutableArray *)devices {
+    AVCaptureDeviceDiscoverySession *videoevicesSession
+        = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeBuiltInWideAngleCamera ]
+                                                                 mediaType:AVMediaTypeVideo
+                                                                  position:AVCaptureDevicePositionUnspecified];
+    for (AVCaptureDevice *device in videoevicesSession.devices) {
+        NSString *position = @"unknown";
+        if (device.position == AVCaptureDevicePositionBack) {
+            position = @"environment";
+        } else if (device.position == AVCaptureDevicePositionFront) {
+            position = @"user";
+        }
+        NSString *label = @"Unknown video device";
+        if (device.localizedName != nil) {
+            label = device.localizedName;
+        }
+        [devices addObject:@{
+                             @"facing": position,
+                             @"deviceId": device.uniqueID,
+                             @"groupId": @"",
+                             @"label": label,
+                             @"kind": DEVICE_KIND_VIDEO_INPUT,
+                             }];
+    }
+}
+
+- (void)fillAudioDevices:(NSMutableArray *)devices {
+    NSString * wiredOrEarpieceLabel = self.hasWiredHeadset ? @"Wired headset" : @"Phone earpiece";
+    [devices addObject:@{
+                         @"deviceId": WIRED_OR_EARPIECE_DEVICE_ID,
+                         @"groupId": @"",
+                         @"label": wiredOrEarpieceLabel,
+                         @"kind": DEVICE_KIND_AUDIO,
+                         }];
+    
+    [devices addObject:@{
+                         @"deviceId": SPEAKERPHONE_DEVICE_ID,
+                         @"groupId": @"",
+                         @"label": @"Speakerphone",
+                         @"kind": DEVICE_KIND_AUDIO,
+                         }];
+    
+    if(self.hasBluetoothDevice && !self.hasWiredHeadset){
+        [devices addObject:@{
+                         @"deviceId": BLUETOOTH_DEVICE_ID,
+                         @"groupId": @"",
+                         @"label": @"Bluetooth",
+                         @"kind": DEVICE_KIND_AUDIO,
+                         }];
+    }
+}
+
+- (BOOL)hasWiredHeadset {
+    AVAudioSession *audioSession = AVAudioSession.sharedInstance;
+    NSArray<AVAudioSessionPortDescription *> *availableInputs = [audioSession availableInputs];
+    for (AVAudioSessionPortDescription *device in availableInputs) {
+        NSString* portType = device.portType;
+        if([portType isEqualToString:AVAudioSessionPortHeadphones] ||
+           [portType isEqualToString:AVAudioSessionPortHeadsetMic] ){
+            return true;
+        }
+    }
+    return false;
+}
+    
+- (BOOL)hasBluetoothDevice {
+    AVAudioSession *audioSession = AVAudioSession.sharedInstance;
+
+    NSArray<AVAudioSessionPortDescription *> *availableInputs = [audioSession availableInputs];
+    for (AVAudioSessionPortDescription *device in availableInputs) {
+        if([self isBluetoothDevice:[device portType]]){
+            return true;
+        }
+    }
+
+    NSArray<AVAudioSessionPortDescription *> *outputs = [[audioSession currentRoute] outputs];
+    for (AVAudioSessionPortDescription *device in outputs) {
+        if([self isBluetoothDevice:[device portType]]){
+            return true;
+        }
+    }
+    return false;
+}
+
+- (BOOL)isBluetoothDevice:(NSString*)portType {
+    BOOL isBluetooth;
+    isBluetooth = ([portType isEqualToString:AVAudioSessionPortBluetoothA2DP] ||
+                   [portType isEqualToString:AVAudioSessionPortBluetoothHFP]);
+    if (@available(iOS 7.0, *)) {
+        isBluetooth |= [portType isEqualToString:AVAudioSessionPortBluetoothLE];
+    }
+    return isBluetooth;
+}
+
+- (BOOL)isBuiltInSpeaker:(NSString*)portType {
+    return [portType isEqualToString:AVAudioSessionPortBuiltInSpeaker];
+}
+
+- (BOOL)isBuiltInEarpieceHeadset:(NSString*)portType {
+    return ([portType isEqualToString:AVAudioSessionPortBuiltInReceiver] ||
+            [portType isEqualToString:AVAudioSessionPortHeadphones] ||
+            [portType isEqualToString:AVAudioSessionPortHeadsetMic] );
+}
+
+- (BOOL)isBuiltInMic:(NSString*)portType {
+    return ([portType isEqualToString:AVAudioSessionPortBuiltInMic]);
+}
+
+
+RCT_EXPORT_METHOD(getAudioDevice: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    NSLog(@"[Daily] getAudioDevice");
+    AVAudioSession *audioSession = AVAudioSession.sharedInstance;
+    NSArray<AVAudioSessionPortDescription *> *currentRoutes = [[audioSession currentRoute] outputs];
+    if([currentRoutes count] > 0){
+        NSString* currentPortType = [currentRoutes[0] portType];
+        NSLog(@"[Daily] currentPortType: %@", currentPortType);
+        if([self isBluetoothDevice:currentPortType]){
+            return resolve(BLUETOOTH_DEVICE_ID);
+        } else if([self isBuiltInSpeaker:currentPortType]){
+            return resolve(SPEAKERPHONE_DEVICE_ID);
+        } else if([self isBuiltInEarpieceHeadset:currentPortType]){
+            return resolve(WIRED_OR_EARPIECE_DEVICE_ID);
+        }
+    }
+    return resolve(SPEAKERPHONE_DEVICE_ID);
+}
+
+// Some reference links explaining how the audio from IOs works and sample code
+// https://stephen-chen.medium.com/how-to-add-audio-device-action-sheet-to-your-ios-app-e6bc401ccdbc
+// https://github.com/xialin/AudioSessionManager/blob/master/AudioSessionManager.m
+RCT_EXPORT_METHOD(setAudioDevice:(NSString*)deviceId) {
+    NSLog(@"[Daily] setAudioDevice: %@", deviceId);
+    
+    [self setAudioMode: AUDIO_MODE_USER_SPECIFIED_ROUTE];
+    self.userSelectedDevice = deviceId;
+    
+    // Ducking other apps' audio implicitly enables allowing mixing audio with
+    // other apps, which allows this app to stay alive in the backgrounnd during
+    // a call (assuming it has the voip background mode set).
+    AVAudioSessionCategoryOptions categoryOptions = (AVAudioSessionCategoryOptionDuckOthers);
+    NSString *mode = AVAudioSessionModeVoiceChat;
+    
+    // Earpiece: is default route for a call.
+    // Speaker: the speaker is the default output audio for like music, video, ring tone.
+    // Bluetooth: whenever a bluetooth device connected, the bluetooth device will become the default audio route.
+    // Headphones: whenever any headphones plugged in, it becomes the default audio route even there is also bluetooth device.
+    //  And it overwrites the handset(iPhone) option, which means you cannot change to the earpiece, bluetooth.
+    if([WIRED_OR_EARPIECE_DEVICE_ID isEqualToString: deviceId]){
+        //we dont need to add anything more
+        NSLog(@"[Daily] configuring output to EARPIECE_HEADSET");
+    }else if([SPEAKERPHONE_DEVICE_ID isEqualToString: deviceId]){
+        NSLog(@"[Daily] configuring output to SPEAKER");
+        categoryOptions |= AVAudioSessionCategoryOptionDefaultToSpeaker;
+        mode = AVAudioSessionModeVideoChat;
+    }else if([BLUETOOTH_DEVICE_ID isEqualToString: deviceId]){
+        NSLog(@"[Daily] configuring output to BLUETOOTH");
+        categoryOptions |= AVAudioSessionCategoryOptionAllowBluetooth;
+    }else {
+        NSLog(@"[Daily] not recognized output type");
+    }
+    
+    AVAudioSession *audioSession = AVAudioSession.sharedInstance;
+    [self configureAudioSession:audioSession audioMode:mode categoryOptions:categoryOptions];
+    
+    // Force to speaker. We only need to do that the cases a wired headset is connected, but we still want to force to speaker
+    if([SPEAKERPHONE_DEVICE_ID isEqualToString: deviceId]){
+        [audioSession overrideOutputAudioPort: AVAudioSessionPortOverrideSpeaker error: nil];
+    } else if([WIRED_OR_EARPIECE_DEVICE_ID isEqualToString: deviceId]){
+        [audioSession overrideOutputAudioPort: AVAudioSessionPortOverrideNone error: nil];
+        NSArray<AVAudioSessionPortDescription *> *availableInputs = [audioSession availableInputs];
+        for (AVAudioSessionPortDescription *device in availableInputs) {
+            if([self isBuiltInMic:[device portType]]){
+                NSLog(@"[Daily] forcing preferred input to built in device");
+                [audioSession setPreferredInput:device error:nil];
+                return;
+            }
+        }
+    }
+}
+
+- (void)configureAudioSession:(nonnull AVAudioSession *)audioSession
+              audioMode:(nonnull NSString *)mode
+              categoryOptions: (AVAudioSessionCategoryOptions) categoryOptions
+{
+    // We need to set the mode before set the category, because when setting the node It can automatically change the categories.
+    // This way we can enforce the categories that we want later.
+    [self audioSessionSetMode:mode toSession:audioSession];
+    [self audioSessionSetCategory:AVAudioSessionCategoryPlayAndRecord toSession:audioSession options:categoryOptions];
+}
+
+- (void)audioSessionSetCategory:(NSString *)audioCategory
+                      toSession:(AVAudioSession *)audioSession
+                        options:(AVAudioSessionCategoryOptions)options
+{
+  @try {
+    [audioSession setCategory:audioCategory
+                  withOptions:options
+                        error:nil];
+    NSLog(@"[Daily] audioSession.setCategory: %@, withOptions: %lu success", audioCategory, (unsigned long)options);
+  } @catch (NSException *e) {
+    NSLog(@"[Daily] audioSession.setCategory: %@, withOptions: %lu fail: %@", audioCategory, (unsigned long)options, e.reason);
+  }
+}
+
+- (void)audioSessionSetMode:(NSString *)audioMode
+                  toSession:(AVAudioSession *)audioSession
+{
+  @try {
+    [audioSession setMode:audioMode error:nil];
+    NSLog(@"[Daily] audioSession.setMode(%@) success", audioMode);
+  } @catch (NSException *e) {
+    NSLog(@"[Daily] audioSession.setMode(%@) fail: %@", audioMode, e.reason);
+  }
+}
+
+- (void)devicesChanged:(NSNotification *)notification {
+    // Possible change reasons: AVAudioSessionRouteChangeReasonOldDeviceUnavailable AVAudioSessionRouteChangeReasonNewDeviceAvailable
+    NSInteger changeReason = [[notification.userInfo objectForKey:AVAudioSessionRouteChangeReasonKey] integerValue];
+    NSLog(@"[Daily] devicesChanged %zd", changeReason);
+    
+    // AVAudioSessionRouteDescription *oldRoute = [notification.userInfo objectForKey:AVAudioSessionRouteChangePreviousRouteKey];
+    // NSString *oldOutput = [[oldRoute.outputs objectAtIndex:0] portType];
+    // AVAudioSessionRouteDescription *newRoute = [audioSession currentRoute];
+    // NSString *newOutput = [[newRoute.outputs objectAtIndex:0] portType];
+    
+    [self sendEventWithName:kEventMediaDevicesOnDeviceChange body:@{}];
+}
+
+RCT_EXPORT_METHOD(startMediaDevicesEventMonitor) {
+    NSLog(@"[Daily] startMediaDevicesEventMonitor");
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(devicesChanged:) name:AVAudioSessionRouteChangeNotification object:nil];
+}
+
+@end

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -184,50 +184,52 @@ RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints
 
 #pragma mark - Other stream related APIs
 
-RCT_EXPORT_METHOD(enumerateDevices:(RCTResponseSenderBlock)callback)
-{
-    NSMutableArray *devices = [NSMutableArray array];
-    AVCaptureDeviceDiscoverySession *videoevicesSession
-        = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeBuiltInWideAngleCamera ]
-                                                                 mediaType:AVMediaTypeVideo
-                                                                  position:AVCaptureDevicePositionUnspecified];
-    for (AVCaptureDevice *device in videoevicesSession.devices) {
-        NSString *position = @"unknown";
-        if (device.position == AVCaptureDevicePositionBack) {
-            position = @"environment";
-        } else if (device.position == AVCaptureDevicePositionFront) {
-            position = @"front";
-        }
-        NSString *label = @"Unknown video device";
-        if (device.localizedName != nil) {
-            label = device.localizedName;
-        }
-        [devices addObject:@{
-                             @"facing": position,
-                             @"deviceId": device.uniqueID,
-                             @"groupId": @"",
-                             @"label": label,
-                             @"kind": @"videoinput",
-                             }];
-    }
-    AVCaptureDeviceDiscoverySession *audioDevicesSession
-        = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeBuiltInMicrophone ]
-                                                                 mediaType:AVMediaTypeAudio
-                                                                  position:AVCaptureDevicePositionUnspecified];
-    for (AVCaptureDevice *device in audioDevicesSession.devices) {
-        NSString *label = @"Unknown audio device";
-        if (device.localizedName != nil) {
-            label = device.localizedName;
-        }
-        [devices addObject:@{
-                             @"deviceId": device.uniqueID,
-                             @"groupId": @"",
-                             @"label": label,
-                             @"kind": @"audioinput",
-                             }];
-    }
-    callback(@[devices]);
-}
+// Disabling this method, we are implementing that inside of WebRTCModule+DevicesManager to list also the output devices
+// and keep all the logic related with the devices in a single place
+//RCT_EXPORT_METHOD(enumerateDevices:(RCTResponseSenderBlock)callback)
+//{
+//    NSMutableArray *devices = [NSMutableArray array];
+//    AVCaptureDeviceDiscoverySession *videoevicesSession
+//        = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeBuiltInWideAngleCamera ]
+//                                                                 mediaType:AVMediaTypeVideo
+//                                                                  position:AVCaptureDevicePositionUnspecified];
+//    for (AVCaptureDevice *device in videoevicesSession.devices) {
+//        NSString *position = @"unknown";
+//        if (device.position == AVCaptureDevicePositionBack) {
+//            position = @"environment";
+//        } else if (device.position == AVCaptureDevicePositionFront) {
+//            position = @"front";
+//        }
+//        NSString *label = @"Unknown video device";
+//        if (device.localizedName != nil) {
+//            label = device.localizedName;
+//        }
+//        [devices addObject:@{
+//                             @"facing": position,
+//                             @"deviceId": device.uniqueID,
+//                             @"groupId": @"",
+//                             @"label": label,
+//                             @"kind": @"videoinput",
+//                             }];
+//    }
+//    AVCaptureDeviceDiscoverySession *audioDevicesSession
+//        = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeBuiltInMicrophone ]
+//                                                                 mediaType:AVMediaTypeAudio
+//                                                                  position:AVCaptureDevicePositionUnspecified];
+//    for (AVCaptureDevice *device in audioDevicesSession.devices) {
+//        NSString *label = @"Unknown audio device";
+//        if (device.localizedName != nil) {
+//            label = device.localizedName;
+//        }
+//        [devices addObject:@{
+//                             @"deviceId": device.uniqueID,
+//                             @"groupId": @"",
+//                             @"label": label,
+//                             @"kind": @"audioinput",
+//                             }];
+//    }
+//    callback(@[devices]);
+//}
 
 RCT_EXPORT_METHOD(mediaStreamCreate:(nonnull NSString *)streamID)
 {

--- a/ios/RCTWebRTC/WebRTCModule.h
+++ b/ios/RCTWebRTC/WebRTCModule.h
@@ -32,6 +32,7 @@ static NSString *const kEventPeerConnectionDidOpenDataChannel = @"peerConnection
 static NSString *const kEventDataChannelStateChanged = @"dataChannelStateChanged";
 static NSString *const kEventDataChannelReceiveMessage = @"dataChannelReceiveMessage";
 static NSString *const kEventMediaStreamTrackMuteChanged = @"mediaStreamTrackMuteChanged";
+static NSString *const kEventMediaDevicesOnDeviceChange = @"mediaDevicesOnDeviceChange";
 
 @interface WebRTCModule : RCTEventEmitter <RCTBridgeModule>
 

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -114,7 +114,8 @@ RCT_EXPORT_MODULE();
     kEventPeerConnectionDidOpenDataChannel,
     kEventDataChannelStateChanged,
     kEventDataChannelReceiveMessage,
-    kEventMediaStreamTrackMuteChanged
+    kEventMediaStreamTrackMuteChanged,
+    kEventMediaDevicesOnDeviceChange,
   ];
 }
 

--- a/src/MediaDevices.js
+++ b/src/MediaDevices.js
@@ -1,15 +1,21 @@
-
 import { NativeModules } from 'react-native';
 import { defineCustomEventTarget } from 'event-target-shim';
 
 import getDisplayMedia from './getDisplayMedia';
 import getUserMedia from './getUserMedia';
 
+import EventEmitter from './EventEmitter';
+import RTCEvent from './RTCEvent';
 const { WebRTCModule } = NativeModules;
 
 const MEDIA_DEVICES_EVENTS = ['devicechange'];
 
 class MediaDevices extends defineCustomEventTarget(...MEDIA_DEVICES_EVENTS) {
+    constructor() {
+        super();
+        this._registerEvents();
+    }
+
     /**
      * W3C "Media Capture and Streams" compatible {@code enumerateDevices}
      * implementation.
@@ -39,6 +45,15 @@ class MediaDevices extends defineCustomEventTarget(...MEDIA_DEVICES_EVENTS) {
      */
     getUserMedia(constraints) {
         return getUserMedia(constraints);
+    }
+
+    _registerEvents(): void {
+        console.log('MediaDevices _registerEvents invoked');
+        WebRTCModule.startMediaDevicesEventMonitor();
+        EventEmitter.addListener('mediaDevicesOnDeviceChange', ev => {
+            console.log('MediaDevices => mediaDevicesOnDeviceChange');
+            this.dispatchEvent(new RTCEvent('devicechange'));
+        });
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-
 import ScreenCapturePickerView from './ScreenCapturePickerView';
 import RTCPeerConnection from './RTCPeerConnection';
 import RTCIceCandidate from './RTCIceCandidate';
@@ -35,6 +34,10 @@ function registerGlobals() {
     navigator.mediaDevices.getUserMedia = mediaDevices.getUserMedia.bind(mediaDevices);
     navigator.mediaDevices.getDisplayMedia = mediaDevices.getDisplayMedia.bind(mediaDevices);
     navigator.mediaDevices.enumerateDevices = mediaDevices.enumerateDevices.bind(mediaDevices);
+    navigator.mediaDevices.addEventListener = mediaDevices.addEventListener.bind(mediaDevices);
+    mediaDevices.addEventListener('devicechange', () => {
+        if (navigator.mediaDevices.ondevicechange) navigator.mediaDevices.ondevicechange();
+    });
 
     global.RTCPeerConnection = RTCPeerConnection;
     global.RTCIceCandidate = RTCIceCandidate;


### PR DESCRIPTION
EnumerateDevices
-------------------
The default `react-native-webrtc` library has some limitation when implementing the `enumerateDevices` method:
- Output devices aren’t included for both IOs and Android;
- For android, It was always adding a single device for audio input, fixed on the code. More info can be found on this issue:
    - https://github.com/react-native-webrtc/react-native-webrtc/issues/1116#issuecomment-1023934218
- For IOs, in the tests made so far, It was always showing a single device, but the device change in case the headphone is plugged or not in the smartphone. It didn't show the bluetooth device;

So the first part of this PR, is make the react-native-webrtc return both input and output devices, for both IOs and Android.

Full details of this change may be found in the following Linear ticket:
https://linear.app/dailyco/issue/ENG-3911/react-native-webrtc-implement-to-enumeratedevices-return-all-audio
https://linear.app/dailyco/issue/ENG-4100/react-native-webrtc-support-ondevicechange-from-mediadevices
https://linear.app/dailyco/issue/ENG-4028/interaction-between-the-setaudioroute-and-our-current

setAudioDevice
-------------------
Different from a desktop or a web version, where we can choose a different device for the input and the output, for both Android and IOs, what we are able to do is basically to choose the audio route, and It will influentiate in both the input and output. 

We are **not** able for example: 
- Use the output from the bluetooth, but use the builtin microphone for a call;
- Use the Speaker but use the micrphone from the headset that is connected;

So all we can do is:
- Use the built in microphone or wired headset, in case one is connected;
- Use the speaker;
- Use a bluetooth headset;
 
Based on that, for each audio device that we list from the `enumerateDevices`, for both input and output, we also have an additional field, audioRoute, that shows which route should be used in case we want that device to be used.

**_When we change the route, we are going to impact both the input and the output device that is selected._** 

Full details of this change may be found in the following Linear ticket:
https://linear.app/dailyco/issue/ENG-3913/react-native-webrtc-create-the-concept-of-audio-route

getAudioDevice
-------------------
Return the information about what is the current audioRoute that is in use. That will be needed to implement `getInputDevices` on `react-native-daily-j`s.

ondevicechange
-------------------
Add support for the method ondevicechange from mediaDevices. This way we can know when a device is added or removed so we can refresh our list of devices:
https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/devicechange_event

Testing the changes
-------------------
We are going the follow environment:
- Pluot core, branch [rn-support-devices](https://github.com/daily-co/pluot-core/tree/rn-support-devices), the changes can be seen [here](https://github.com/daily-co/pluot-core/pull/4664)
- Playground app, branch [rn-webrtc-devices-support](https://github.com/daily-co/rn-daily-js-playground/tree/rn-webrtc-devices-support), the changes can be seen [here](https://github.com/daily-co/rn-daily-js-playground/pull/82) 


**Let me know about what do you think about this proposal, if you think makes sense how we are creating the enumerateDevices, and the relationship between the devices and the audioRoute.**

While developing this PR we have found an issue, that when plugging a bluetooth device the app crashes. We need to fix this issue before be able to complete test this PR.
daily-co/rn-daily-js-playground#84


