### PR TITLE
Support ondevicechange from mediaDevices

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCDevicesManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCDevicesManager.java
@@ -1,6 +1,7 @@
 package com.oney.WebRTCModule;
 
 import android.content.Context;
+import android.media.AudioDeviceCallback;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
 import android.util.Log;
@@ -20,6 +21,7 @@ import java.util.Arrays;
 public class WebRTCDevicesManager {
 
     static final String TAG = WebRTCDevicesManager.class.getCanonicalName();
+    static final String ON_DEVICE_CHANGE_EVENT = "mediaDevicesOnDeviceChange";
 
     public enum DeviceKind {
         // Those constants are defined on the webrtc specification
@@ -78,14 +80,32 @@ public class WebRTCDevicesManager {
         }
     }
 
+    private AudioDeviceCallback audioDeviceCallback = new AudioDeviceCallback() {
+        @Override
+        public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
+            WebRTCDevicesManager.this.webRTCModule.sendEvent(ON_DEVICE_CHANGE_EVENT, null);
+        }
+
+        @Override
+        public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
+            WebRTCDevicesManager.this.webRTCModule.sendEvent(ON_DEVICE_CHANGE_EVENT, null);
+        }
+    };
+
     private final CameraEnumerator cameraEnumerator;
     private AudioManager audioManager;
     private ReactApplicationContext reactContext;
+    private final WebRTCModule webRTCModule;
 
-    public WebRTCDevicesManager(ReactApplicationContext reactContext) {
+    public WebRTCDevicesManager(WebRTCModule webRTCModule, ReactApplicationContext reactContext) {
+        this.webRTCModule = webRTCModule;
         this.reactContext = reactContext;
         this.audioManager = (AudioManager) reactContext.getSystemService(Context.AUDIO_SERVICE);
         this.cameraEnumerator = this.createCameraEnumerator();
+    }
+
+    public void startMediaDevicesEventMonitor(){
+        this.audioManager.registerAudioDeviceCallback(audioDeviceCallback, null);
     }
 
     private CameraEnumerator createCameraEnumerator() {

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -1023,6 +1023,11 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void startMediaDevicesEventMonitor() {
+        //TODO implementar
+    }
+
+    @ReactMethod
     public void getAudioRoute(Promise promise) {
         ThreadUtils.runOnExecutor(() -> {
             int audioRoute = this.webRTCDevicesManager.getAudioRoute();

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -134,7 +134,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 .createPeerConnectionFactory();
 
         getUserMediaImpl = new GetUserMediaImpl(this, reactContext);
-        webRTCDevicesManager = new WebRTCDevicesManager(reactContext);
+        webRTCDevicesManager = new WebRTCDevicesManager(this, reactContext);
     }
 
     @NonNull
@@ -1024,7 +1024,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void startMediaDevicesEventMonitor() {
-        //TODO implementar
+        this.webRTCDevicesManager.startMediaDevicesEventMonitor();
     }
 
     @ReactMethod

--- a/ios/RCTWebRTC/WebRTCModule+DevicesManager.m
+++ b/ios/RCTWebRTC/WebRTCModule+DevicesManager.m
@@ -289,4 +289,22 @@ RCT_EXPORT_METHOD(setAudioRoute:(nonnull NSNumber*)audioRoute) {
   }
 }
 
+- (void)devicesChanged:(NSNotification *)notification {
+    // Possible change reasons: AVAudioSessionRouteChangeReasonOldDeviceUnavailable AVAudioSessionRouteChangeReasonNewDeviceAvailable
+    NSInteger changeReason = [[notification.userInfo objectForKey:AVAudioSessionRouteChangeReasonKey] integerValue];
+    NSLog(@"[Daily] devicesChanged %zd", changeReason);
+    
+    // AVAudioSessionRouteDescription *oldRoute = [notification.userInfo objectForKey:AVAudioSessionRouteChangePreviousRouteKey];
+    // NSString *oldOutput = [[oldRoute.outputs objectAtIndex:0] portType];
+    // AVAudioSessionRouteDescription *newRoute = [audioSession currentRoute];
+    // NSString *newOutput = [[newRoute.outputs objectAtIndex:0] portType];
+    
+    [self sendEventWithName:kEventMediaDevicesOnDeviceChange body:@{}];
+}
+
+RCT_EXPORT_METHOD(startMediaDevicesEventMonitor) {
+    NSLog(@"[Daily] startMediaDevicesEventMonitor");
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(devicesChanged:) name:AVAudioSessionRouteChangeNotification object:nil];
+}
+
 @end

--- a/ios/RCTWebRTC/WebRTCModule.h
+++ b/ios/RCTWebRTC/WebRTCModule.h
@@ -32,6 +32,7 @@ static NSString *const kEventPeerConnectionDidOpenDataChannel = @"peerConnection
 static NSString *const kEventDataChannelStateChanged = @"dataChannelStateChanged";
 static NSString *const kEventDataChannelReceiveMessage = @"dataChannelReceiveMessage";
 static NSString *const kEventMediaStreamTrackMuteChanged = @"mediaStreamTrackMuteChanged";
+static NSString *const kEventMediaDevicesOnDeviceChange = @"mediaDevicesOnDeviceChange";
 
 @interface WebRTCModule : RCTEventEmitter <RCTBridgeModule>
 

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -114,7 +114,8 @@ RCT_EXPORT_MODULE();
     kEventPeerConnectionDidOpenDataChannel,
     kEventDataChannelStateChanged,
     kEventDataChannelReceiveMessage,
-    kEventMediaStreamTrackMuteChanged
+    kEventMediaStreamTrackMuteChanged,
+    kEventMediaDevicesOnDeviceChange,
   ];
 }
 

--- a/src/MediaDevices.js
+++ b/src/MediaDevices.js
@@ -1,15 +1,21 @@
-
 import { NativeModules } from 'react-native';
 import { defineCustomEventTarget } from 'event-target-shim';
 
 import getDisplayMedia from './getDisplayMedia';
 import getUserMedia from './getUserMedia';
 
+import EventEmitter from './EventEmitter';
+import RTCEvent from './RTCEvent';
 const { WebRTCModule } = NativeModules;
 
 const MEDIA_DEVICES_EVENTS = ['devicechange'];
 
 class MediaDevices extends defineCustomEventTarget(...MEDIA_DEVICES_EVENTS) {
+    constructor() {
+        super();
+        this._registerEvents();
+    }
+
     /**
      * W3C "Media Capture and Streams" compatible {@code enumerateDevices}
      * implementation.
@@ -39,6 +45,15 @@ class MediaDevices extends defineCustomEventTarget(...MEDIA_DEVICES_EVENTS) {
      */
     getUserMedia(constraints) {
         return getUserMedia(constraints);
+    }
+
+    _registerEvents(): void {
+        console.log('MediaDevices _registerEvents invoked');
+        WebRTCModule.startMediaDevicesEventMonitor();
+        EventEmitter.addListener('mediaDevicesOnDeviceChange', ev => {
+            console.log('MediaDevices => mediaDevicesOnDeviceChange');
+            this.dispatchEvent(new RTCEvent('devicechange'));
+        });
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,9 @@ function registerGlobals() {
     navigator.mediaDevices.getDisplayMedia = mediaDevices.getDisplayMedia.bind(mediaDevices);
     navigator.mediaDevices.enumerateDevices = mediaDevices.enumerateDevices.bind(mediaDevices);
     navigator.mediaDevices.addEventListener = mediaDevices.addEventListener.bind(mediaDevices);
+    mediaDevices.addEventListener('devicechange', () => {
+        if (navigator.mediaDevices.ondevicechange) navigator.mediaDevices.ondevicechange();
+    });
 
     global.RTCPeerConnection = RTCPeerConnection;
     global.RTCIceCandidate = RTCIceCandidate;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-
 import ScreenCapturePickerView from './ScreenCapturePickerView';
 import RTCPeerConnection from './RTCPeerConnection';
 import RTCIceCandidate from './RTCIceCandidate';
@@ -35,6 +34,7 @@ function registerGlobals() {
     navigator.mediaDevices.getUserMedia = mediaDevices.getUserMedia.bind(mediaDevices);
     navigator.mediaDevices.getDisplayMedia = mediaDevices.getDisplayMedia.bind(mediaDevices);
     navigator.mediaDevices.enumerateDevices = mediaDevices.enumerateDevices.bind(mediaDevices);
+    navigator.mediaDevices.addEventListener = mediaDevices.addEventListener.bind(mediaDevices);
 
     global.RTCPeerConnection = RTCPeerConnection;
     global.RTCIceCandidate = RTCIceCandidate;


### PR DESCRIPTION
Add support for the method ondevicechange from mediaDevices. This way we can know when a device is added or removed so we can refresh our list of devices:
https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/devicechange_event

More details can be found on this linear ticket:
https://linear.app/dailyco/issue/ENG-4100/react-native-webrtc-support-ondevicechange-from-mediadevices

This PR, depends on this [PR](https://github.com/daily-co/react-native-webrtc/pull/22).

This is still a proposal.
