### PR TITLE
Provide better control over our audio sessions on react-native

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+DailyDevicesManager.m
+++ b/ios/RCTWebRTC/WebRTCModule+DailyDevicesManager.m
@@ -179,7 +179,7 @@ RCT_EXPORT_METHOD(setAudioDevice:(NSString*)deviceId) {
     // Ducking other apps' audio implicitly enables allowing mixing audio with
     // other apps, which allows this app to stay alive in the backgrounnd during
     // a call (assuming it has the voip background mode set).
-    AVAudioSessionCategoryOptions categoryOptions = (AVAudioSessionCategoryOptionDuckOthers);
+    AVAudioSessionCategoryOptions categoryOptions = (AVAudioSessionCategoryOptionMixWithOthers);
     NSString *mode = AVAudioSessionModeVoiceChat;
     
     // Earpiece: is default route for a call.


### PR DESCRIPTION
More info on this linear ticket:
- https://linear.app/dailyco/issue/ENG-5202/provide-better-control-over-our-audio-sessions-on-react-native

Draft PR to show the different behaviors of AVAudioSession.

What I have noticed:
- Replacing from `AVAudioSessionCategoryOptionDuckOthers` to `AVAudioSessionCategoryOptionMixWithOthers`, has improved the volume a little bit, my impression is that instead of `20-30%` of volume that It was before, just changing this config the volume is around `50-60%`.
- If we manually control the audio, and then enable or disable the audio Daily audio session, we can see that when the Daily audio session is disabled, we are able to hear the youtube at what looks like 100% volume.

With the code below we are able to make those tests.

This PR has just the intention to show the different behaviors, so we can decide what alternative we would like to proceed, of if we are going to proceed exactly as suggested below, where we are handling the audio manually, but leaving to the user the option of when he wishes to enable or disable the Daily audio session. 

This comment I have extrated from the header of `RTCAudioSession`:
_This property, `setIsAudioEnabled`, is only effective if `useManualAudio` is YES. Represents permission for WebRTC to initialize the VoIP audio unit. When set to NO, if the VoIP audio unit used by WebRTC is active, it will be stopped and uninitialized. This will stop incoming and outgoing audio. When set to YES, WebRTC will initialize and start the audio unit when it is needed (e.g. due to establishing an audio connection). 
**This property was introduced to work around an issue where if an AVPlayer is playing audio while the VoIP audio unit is initialized, its audio would be either cut off completely or played at a reduced volume.** By preventing the audio unit from being initialized until after the audio has completed, we are able to prevent the abrupt cutoff._

```
import React, {useEffect, useState, useCallback} from 'react';
import {Button, View} from 'react-native';
import Daily from '@daily-co/react-native-daily-js';
import YoutubePlayer from 'react-native-youtube-iframe';

import {NativeModules} from 'react-native';
const {WebRTCModule} = NativeModules;

const App = () => {
  const [callObject, setCallObject] = useState(null);
  const [audioSessionEnabled, setaudioSessionEnabled] = useState(true);

  const toggleDailyAudioSessionEnabled = useCallback(() => {
    let audioSessionEnabledNew = !audioSessionEnabled;
    setaudioSessionEnabled(audioSessionEnabledNew);
    WebRTCModule.setDailyAudioSessionEnabled(audioSessionEnabledNew);
  }, [audioSessionEnabled]);

  const initializeDaily = async () => {
    const call = Daily.createCallObject();
    await call.join({
      url: 'https://YOUR_URL',
    });
    // disabling the local audio
    call.setLocalAudio(false);
    setCallObject(call);
  };

  useEffect(() => {
    initializeDaily();
    return () => {};
  }, []);

  useEffect(() => {
    if (callObject) {
    }
    return () => {};
  }, [callObject]);

  return (
    <View>
      <YoutubePlayer height={300} videoId={'NWcjOFnsxZ0'} />
      <Button
        title={
          audioSessionEnabled
            ? 'Disable Daily Audio Session'
            : 'Enable Daily Audio Session'
        }
        onPress={toggleDailyAudioSessionEnabled}
      />
    </View>
  );
};

export default App;

``` 