### PR TITLE
Eng 5202 control audio session

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/DailyAudioManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/DailyAudioManager.java
@@ -100,6 +100,12 @@ public class DailyAudioManager implements AudioManager.OnAudioFocusChangeListene
         });
     }
 
+    private boolean isInCall(){
+        int currentAudioMode = this.audioManager.getMode();
+        boolean inCall = (AudioManager.MODE_IN_CALL == currentAudioMode || AudioManager.MODE_RINGTONE == currentAudioMode);
+        return inCall;
+    }
+
     @Override
     public void onAudioFocusChange(int focusChange) {
         executor.execute(() -> {
@@ -114,8 +120,13 @@ public class DailyAudioManager implements AudioManager.OnAudioFocusChangeListene
                 case AudioManager.AUDIOFOCUS_LOSS:
                 case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
                 case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
-                    Log.d(TAG, "onAudioFocusChange: LOSS");
-                    sendAudioFocusChangeEvent(false);
+                    Log.d(TAG, "onAudioFocusChange: LOSS " + focusChange);
+                    // Before Android 12, we are receiving audio focus loss event even if we are not in a call
+                    // So we are going to check if we are or not in a call before we emit this event to daily-js,
+                    // so It can mute the remote participants and not influentiate in the call
+                    if(this.isInCall()){
+                        sendAudioFocusChangeEvent(false);
+                    }
                     break;
                 default:
                     break;

--- a/ios/RCTWebRTC/WebRTCModule+Daily.m
+++ b/ios/RCTWebRTC/WebRTCModule+Daily.m
@@ -60,7 +60,7 @@ RCT_EXPORT_METHOD(enableNoOpRecordingEnsuringBackgroundContinuity:(BOOL)enable) 
   if (enable) {
     [RTCAudioSession.sharedInstance addDelegate:self];
   }
-  
+
   dispatch_async(self.captureSessionQueue, ^{
     if (enable) {
       if (self.captureSession) {
@@ -153,7 +153,7 @@ RCT_EXPORT_METHOD(setDailyAudioMode:(NSString *)audioMode) {
   // other apps, which allows this app to stay alive in the backgrounnd during
   // a call (assuming it has the voip background mode set).
   AVAudioSessionCategoryOptions categoryOptions = (AVAudioSessionCategoryOptionAllowBluetooth |
-                                                   AVAudioSessionCategoryOptionDuckOthers);
+                                                   AVAudioSessionCategoryOptionMixWithOthers);
   if ([audioMode isEqualToString:AUDIO_MODE_VIDEO_CALL]) {
     categoryOptions |= AVAudioSessionCategoryOptionDefaultToSpeaker;
   }

--- a/ios/RCTWebRTC/WebRTCModule+DailyDevicesManager.m
+++ b/ios/RCTWebRTC/WebRTCModule+DailyDevicesManager.m
@@ -179,7 +179,7 @@ RCT_EXPORT_METHOD(setAudioDevice:(NSString*)deviceId) {
     // Ducking other apps' audio implicitly enables allowing mixing audio with
     // other apps, which allows this app to stay alive in the backgrounnd during
     // a call (assuming it has the voip background mode set).
-    AVAudioSessionCategoryOptions categoryOptions = (AVAudioSessionCategoryOptionDuckOthers);
+    AVAudioSessionCategoryOptions categoryOptions = (AVAudioSessionCategoryOptionMixWithOthers);
     NSString *mode = AVAudioSessionModeVoiceChat;
     
     // Earpiece: is default route for a call.


### PR DESCRIPTION
Improving the way that we are handling audio in order to work better with apps that need to execute other audios at the same time.

More details can be found on this linear [ticket](https://linear.app/dailyco/issue/ENG-5202/provide-better-control-over-our-audio-sessions-on-react-native) and on this previous [PR](https://github.com/daily-co/react-native-webrtc/pull/27) that is now closed.

Changes on this PR:
- Android: Just emitting the audio focus loss event on Android if we are in a call. This will prevent us from muting the remote participants in versions of Android previously Android 12, where we were receiving this event even when Android was mixing the audio.
- iOS: Replacing from `AVAudioSessionCategoryOptionDuckOthers` to `AVAudioSessionCategoryOptionMixWithOthers`, to improve the volume without the side effect of not been able to hear the remote participants anymore. More details on this can be found on the older PR that we have mentioned above.