### PR TITLE
Fixing Samsung camera issue of multiple cameras

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
@@ -9,7 +9,10 @@ import org.webrtc.CameraVideoCapturer;
 import org.webrtc.VideoCapturer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 public class CameraCaptureController extends AbstractVideoCaptureController {
     /**
@@ -31,28 +34,31 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
      * implementation does not do anything but logging unspecific to the camera
      * device's name anyway.
      */
-    private final CameraEventsHandler cameraEventsHandler = new CameraEventsHandler();
+    private final CameraEventsHandler cameraEventsHandler = new CameraEventsHandler() {
+        @Override
+        public void onCameraOpening(String cameraName) {
+            super.onCameraOpening(cameraName);
+            // Checking if we need to switch the camera
+            Log.d(TAG, "onCameraOpening, facing mode when has stopped capture: " + CameraCaptureController.this.facingModeWhenStoppedCapturing + " ,current: " + CameraCaptureController.this.facingMode());
+            if(facingModeWhenStoppedCapturing != null &&  !CameraCaptureController.this.facingMode().equals(facingModeWhenStoppedCapturing)) {
+                CameraCaptureController.this.restoreTheSelectedCamera();
+            }
+            CameraCaptureController.this.facingModeWhenStoppedCapturing = null;
+        }
+    };
 
     @Override
     public void startCapture() {
+        Log.d(TAG, "Invoking to startCapture, facing mode when has stopped capture: " + this.facingModeWhenStoppedCapturing + " ,current: " + this.facingMode());
         super.startCapture();
         this.isCapturing = true;
-        // Checking if we need to switch the camera
-        if(facingModeWhenStoppedCapturing != null && facingModeWhenStoppedCapturing != facingMode()) {
-            CameraCaptureController.this.switchCamera(new SwitchCameraHandler() {
-                @Override
-                public void onSwitchCameraDone(String facingMode) {
-                    Log.d(TAG, "Restoring to the right camera facing mode: " + facingMode);
-                }
-            });
-        }
-        this.facingModeWhenStoppedCapturing = null;
     }
 
     @Override
     public boolean stopCapture() {
         this.isCapturing = false;
         this.facingModeWhenStoppedCapturing = this.facingMode();
+        Log.d(TAG, "Will stopCapture, current facingMode is " + this.facingModeWhenStoppedCapturing);
         return super.stopCapture();
     }
 
@@ -71,7 +77,32 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
         public void onSwitchCameraDone(String facingMode);
     }
 
+    // Restoring to the camera that the user has chosen while the camera session was destroyed
+    private void restoreTheSelectedCamera(){
+        Log.d(TAG, "Will restore to facing mode " + CameraCaptureController.this.facingMode());
+        String[] deviceNames = cameraEnumerator.getDeviceNames();
+        String deviceToSwitchTo = Arrays.stream(deviceNames).filter((deviceName) -> {
+            Log.d(TAG, "Filtering " + deviceName + " isFrontFacing " + cameraEnumerator.isFrontFacing(deviceName));
+            return cameraEnumerator.isFrontFacing(deviceName) == isFrontFacing;
+        }).findFirst().get();
+        Log.d(TAG, "Invoked restoreTheSelectedCamera, will switch to device:" + deviceToSwitchTo);
+        if (videoCapturer instanceof CameraVideoCapturer) {
+            CameraVideoCapturer capturer = (CameraVideoCapturer) videoCapturer;
+            capturer.switchCamera(new CameraVideoCapturer.CameraSwitchHandler() {
+                @Override
+                public void onCameraSwitchDone(boolean b) {
+                    Log.d(TAG, "Restored to the right camera facing mode: " + facingMode());
+                }
+                @Override
+                public void onCameraSwitchError(String s) {
+                    Log.e(TAG, "Error restoring camera: " + s);
+                }
+            }, deviceToSwitchTo);
+        }
+    }
+
     public void switchCamera(SwitchCameraHandler handler) {
+        Log.d(TAG, "Invoked switchCamera, isCapturing:" + this.isCapturing);
         // When the video is muted, the camera session is destroyed
         // If we try to switch the camera while the session is destroyed
         // we receive this error from libwebrtc: "switchCamera: camera is not running."
@@ -85,6 +116,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
             CameraVideoCapturer capturer = (CameraVideoCapturer) videoCapturer;
             String[] deviceNames = cameraEnumerator.getDeviceNames();
             int deviceCount = deviceNames.length;
+            Log.d(TAG, "Invoked switchCamera, deviceCount:" + deviceCount);
 
             // Nothing to switch to.
             if (deviceCount < 2) {
@@ -92,27 +124,40 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
                 return;
             }
 
+            CameraVideoCapturer.CameraSwitchHandler cameraSwitchHandler = new CameraVideoCapturer.CameraSwitchHandler() {
+                @Override
+                public void onCameraSwitchDone(boolean b) {
+                    Log.d(TAG, "Invoked onCameraSwitchDone, isFrontFacing:" + b);
+                    isFrontFacing = b;
+                    handler.onSwitchCameraDone(facingMode());
+                }
+
+                @Override
+                public void onCameraSwitchError(String s) {
+                    Log.e(TAG, "Error switching camera: " + s);
+                    handler.onSwitchCameraDone(facingMode());
+                }
+            };
             // The usual case.
             if (deviceCount == 2) {
-                capturer.switchCamera(new CameraVideoCapturer.CameraSwitchHandler() {
-                    @Override
-                    public void onCameraSwitchDone(boolean b) {
-                        isFrontFacing = b;
-                        handler.onSwitchCameraDone(facingMode());
-                    }
-
-                    @Override
-                    public void onCameraSwitchError(String s) {
-                        Log.e(TAG, "Error switching camera: " + s);
-                        handler.onSwitchCameraDone(facingMode());
-                    }
-                });
-                return;
+                capturer.switchCamera(cameraSwitchHandler);
+            } else {
+                try{
+                    // We are always selecting the first one that matches the
+                    // opposite facing mode that we currently have.
+                    String deviceToSwitchTo = Arrays.stream(deviceNames).filter((deviceName) -> {
+                        Log.d(TAG, "Filtering " + deviceName + " isFrontFacing " + cameraEnumerator.isFrontFacing(deviceName));
+                        return cameraEnumerator.isFrontFacing(deviceName) != isFrontFacing;
+                    }).findFirst().get();
+                    Log.d(TAG, "Invoked switchCamera, has more than 02 cameras, will switch to device:" + deviceToSwitchTo);
+                    capturer.switchCamera(cameraSwitchHandler, deviceToSwitchTo);
+                }catch (Exception e) {
+                    Log.d(TAG, "Failed to switch the camera device:" + e.getMessage());
+                }
+                // If we are here the device has more than 2 cameras. Cycle through them
+                // and switch to the first one of the desired facing mode.
+                // switchCamera(!isFrontFacing, deviceCount, handler);
             }
-
-            // If we are here the device has more than 2 cameras. Cycle through them
-            // and switch to the first one of the desired facing mode.
-            switchCamera(!isFrontFacing, deviceCount, handler);
         }
     }
 

--- a/android/src/main/java/com/oney/WebRTCModule/DailyWebRTCDevicesManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/DailyWebRTCDevicesManager.java
@@ -101,20 +101,23 @@ public class DailyWebRTCDevicesManager {
 
     private void fillVideoInputDevices(WritableArray enumerateDevicesArray) {
         String[] devices = cameraEnumerator.getDeviceNames();
-        for (int i = 0; i < devices.length; ++i) {
-            String deviceName = devices[i];
-            boolean isFrontFacing;
-            try {
-                // This can throw an exception when using the Camera 1 API.
-                isFrontFacing = cameraEnumerator.isFrontFacing(deviceName);
-            } catch (Exception e) {
-                Log.e(TAG, "Failed to check the facing mode of camera");
-                continue;
-            }
-            String label = isFrontFacing ? "Front camera" : "Rear camera";
-            String deviceID = isFrontFacing ? "CAMERA_USER" : "CAMERA_ENVIRONMENT";
-            WritableMap params = this.createWritableMap(deviceID, label, DeviceKind.VIDEO_INPUT.getKind());
-            params.putString("facing", isFrontFacing ? "user" : "environment");
+        Log.d(TAG, "fillVideoInputDevices video devices: " + Arrays.toString(devices));
+        // FIXME Filipi
+        // We are just considering to always return up to two camera devices
+        // If we return more than two, we are going to need to change our API
+        // And create a method to switch the camera that also allow to receive the camera device name
+        // That we wish to switch to, and test It to see If It is working fine
+        // We may plan to implement that in the future.
+        boolean hasFrontCamera = Arrays.stream(devices).anyMatch(cameraEnumerator::isFrontFacing);
+        if(hasFrontCamera) {
+            WritableMap params = this.createWritableMap("CAMERA_USER", "Front camera", DeviceKind.VIDEO_INPUT.getKind());
+            params.putString("facing",  "user");
+            enumerateDevicesArray.pushMap(params);
+        }
+        boolean hasRearCamera = Arrays.stream(devices).anyMatch(cameraEnumerator::isBackFacing);
+        if(hasRearCamera) {
+            WritableMap params = this.createWritableMap("CAMERA_ENVIRONMENT", "Rear camera", DeviceKind.VIDEO_INPUT.getKind());
+            params.putString("facing",  "environment");
             enumerateDevicesArray.pushMap(params);
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@daily-co/react-native-webrtc",
-  "version": "1.94.1-daily.6",
+  "version": "1.94.1-daily.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@daily-co/react-native-webrtc",
-      "version": "1.94.1-daily.6",
+      "version": "1.94.1-daily.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daily-co/react-native-webrtc",
-  "version": "1.94.1-daily.7",
+  "version": "1.94.1-daily.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/daily-co/react-native-webrtc.git"


### PR DESCRIPTION
This PR has a more simple approach to fix a current issue on Samsung devices.

Samsung devices return more than 02 cameras, they return all available front and back cameras, which usually mean cameras with different levels of zooms or qualities.

So this PR is changing the behavior to always handle and return two cameras, one for the front and the other one for the environment.

What this change will impact:
- This changes the behavior from `react-native-webrtc` when we have more than 02 cameras. Where now when invoking the method `switchCamera`, we are always only to consider the first camera of each facing mode. 
  - This can lead to a different behavior on a Samsung device if the method `cycleCamera` was invoked. Where the user would be able to cycle through all the different cameras.
- But on the other hand, It makes It consistent with the behavior of `enumerateDevices`, where we were returning all the devices but with duplicate Ids, which was leading to errors in the react native apps. 
- And also fix It to make It consistent with the method `setCamera`, where the user is selecting a specific one. Otherwise, it was cycling and never choosing the right camera.

Other fixes: 
- Fixing errors on Samsung devices if we try to restore to the selected camera as soon as we start to capture. On Samsung, the camera was not ready yet;
- Created a new method to restore the camera to the previously selected facing mode (while the video was off), based on the camera name;
- Improving the logs;

Another possible approach, which I believe we can consider, is really fix `react-native-webrtc` to handle more than 02 cameras, in this case we are going to need:
- Fix `enumerateDevices`, to return different deviceIds to each camera;
- Create a new method on `react-native-webrtc` to allow the user to switch to a specific camera, based on the camera name (which will be basically the deviceId), instead of just switching to the next camera with the desired face mode;
- Fix our call machine to invoke this new method when we invoke `setCamera`;

This other approach demands a couple of extra changes, and a new release of `react-native-webrtc`, `daily-js` and `react-native-daily-js`. 

While the first approach only requires a new release of `react-native-webrtc` to test and validate It.. And already has allowed us to validate the behavior of those new methods on Samsung devices. 

But that is now pretty easy in case we already want to evolve to the final solution if we agree that we should always return all possible cameras instead of only 02 (one for each facing mode).