### PR TITLE
Fix an issue where the no-op recording mechanism was erroring on star…

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+Daily.m
+++ b/ios/RCTWebRTC/WebRTCModule+Daily.m
@@ -80,9 +80,14 @@ RCT_EXPORT_METHOD(enableNoOpRecordingEnsuringBackgroundContinuity:(BOOL)enable) 
 // Expects to be invoked from captureSessionQueue
 - (AVCaptureSession *)configuredCaptureSession {
   AVCaptureSession *captureSession = [[AVCaptureSession alloc] init];
-  // Don't automatically configure application audio session, to prevent
-  // configuration "thrashing" once WebRTC audio unit takes the reins.
-  captureSession.automaticallyConfiguresApplicationAudioSession = NO;
+  // Note: we *used* to have the following line:
+  // captureSession.automaticallyConfiguresApplicationAudioSession = NO;
+  // The original reason for it was to "prevent configuration 'thrashing' once
+  // WebRTC audio unit takes the reins." As of 2023-08-23, I (kompfner) haven't
+  // observed any audio misbehavior as a result of removing this line. Keeping
+  // this line, on the other hand, was causing the no-op recording to error on
+  // start, which in turn meant that your app would not stay alive in the 
+  // background if you joined a call with your cam and mic initially off.
   AVCaptureDevice *audioDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
   if (!audioDevice) {
     return nil;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@daily-co/react-native-webrtc",
-  "version": "111.0.0-daily.1",
+  "version": "111.0.0-daily.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@daily-co/react-native-webrtc",
-      "version": "111.0.0-daily.1",
+      "version": "111.0.0-daily.2",
       "license": "MIT",
       "dependencies": {
         "@types/react": "17.0.38",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daily-co/react-native-webrtc",
-  "version": "111.0.0-daily.1",
+  "version": "111.0.0-daily.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/daily-co/react-native-webrtc.git"


### PR DESCRIPTION
…t, resulting in the app not staying alive in the background after joining a call with cam + mic initially off.