### PR TITLE
Disabling audio processing

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -1,5 +1,6 @@
 package com.oney.WebRTCModule;
 
+import android.media.MediaRecorder;
 import android.util.Log;
 import android.util.Pair;
 import android.util.SparseArray;
@@ -91,7 +92,16 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         }
 
         if (adm == null) {
-            adm = JavaAudioDeviceModule.builder(reactContext).setEnableVolumeLogger(false).createAudioDeviceModule();
+            Log.i(TAG, "Creating a custom audio device module!");
+            adm = JavaAudioDeviceModule
+                    .builder(reactContext)
+                    .setEnableVolumeLogger(false)
+                    // Disabling hardware specific settings
+                    .setUseHardwareAcousticEchoCanceler(false)
+                    .setUseHardwareNoiseSuppressor(false)
+                    // bypasses phone mode speech filtering
+                    .setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION)
+                    .createAudioDeviceModule();
         }
 
         Log.d(TAG, "Using video encoder factory: " + encoderFactory.getClass().getCanonicalName());

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -1,5 +1,6 @@
 package com.oney.WebRTCModule;
 
+import android.media.AudioManager;
 import android.media.MediaRecorder;
 import android.util.Log;
 import android.util.Pair;
@@ -93,14 +94,26 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
         if (adm == null) {
             Log.i(TAG, "Creating a custom audio device module!");
+            // TODO: need to check the audio manager instead of always using VOICE_RECOGNITION
+            // But it looks like it is doing the tricky for now.
+            // https://developer.android.com/media/platform/mediarecorder#audiocapture
+            // Note: Most of the audio sources (including DEFAULT) apply processing to the audio signal.
+            // To record raw audio select UNPROCESSED. Some devices do not support unprocessed input.
+            // Call AudioManager.getProperty(android.media.AudioManager.PROPERTY_SUPPORT_AUDIO_SOURCE_UNPROCESSED) first to verify it's available.
+            // If it is not, try using VOICE_RECOGNITION instead, which does not employ AGC or noise suppression.
+            int audioSource = MediaRecorder.AudioSource.VOICE_RECOGNITION;
             adm = JavaAudioDeviceModule
                     .builder(reactContext)
                     .setEnableVolumeLogger(false)
                     // Disabling hardware specific settings
                     .setUseHardwareAcousticEchoCanceler(false)
                     .setUseHardwareNoiseSuppressor(false)
+                    // Depending on the value you choose, Android may enable or disable:
+                    // Noise suppression
+                    // Acoustic echo cancellation
+                    // Automatic gain control (AGC)
                     // bypasses phone mode speech filtering
-                    .setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION)
+                    .setAudioSource(audioSource)
                     .createAudioDeviceModule();
         }
 

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -94,25 +94,39 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
         if (adm == null) {
             Log.i(TAG, "Creating a custom audio device module!");
-            // TODO: need to check the audio manager instead of always using VOICE_RECOGNITION
-            // But it looks like it is doing the tricky for now.
-            // https://developer.android.com/media/platform/mediarecorder#audiocapture
-            // Note: Most of the audio sources (including DEFAULT) apply processing to the audio signal.
-            // To record raw audio select UNPROCESSED. Some devices do not support unprocessed input.
-            // Call AudioManager.getProperty(android.media.AudioManager.PROPERTY_SUPPORT_AUDIO_SOURCE_UNPROCESSED) first to verify it's available.
-            // If it is not, try using VOICE_RECOGNITION instead, which does not employ AGC or noise suppression.
+            /*
+             * TODO (Filipi):
+             * Instead of always forcing VOICE_RECOGNITION, detect the best audio source
+             * by checking device capabilities through AudioManager.
+             *
+             * Background:
+             * - Many audio sources (including DEFAULT) apply signal processing such as
+             *   noise suppression, echo cancellation, and automatic gain control (AGC).
+             * - If you need raw, unprocessed audio, use MediaRecorder.AudioSource.UNPROCESSED.
+             *   However, not all devices support this source.
+             *
+             * VOICE_RECOGNITION is chosen here for now as a safe fallback because it avoids
+             * most unwanted processing while being widely supported.
+             *
+             * Recommended flow:
+             * 1. Query device support for unprocessed audio:
+             *      AudioManager.getProperty(PROPERTY_SUPPORT_AUDIO_SOURCE_UNPROCESSED)
+             * 2. If supported, use UNPROCESSED.
+             * 3. Otherwise, fall back to VOICE_RECOGNITION, which provides minimal
+             *    signal processing (no AGC, no noise suppression).
+             *
+             * Reference:
+             * https://developer.android.com/media/platform/mediarecorder#audiocapture
+             */
             int audioSource = MediaRecorder.AudioSource.VOICE_RECOGNITION;
             adm = JavaAudioDeviceModule
                     .builder(reactContext)
                     .setEnableVolumeLogger(false)
-                    // Disabling hardware specific settings
+                    // Disable hardware AEC/NS so WebRTC can use its own implementations,
+                    // or so that audio remains as close to raw as possible depending on your target.
                     .setUseHardwareAcousticEchoCanceler(false)
                     .setUseHardwareNoiseSuppressor(false)
-                    // Depending on the value you choose, Android may enable or disable:
-                    // Noise suppression
-                    // Acoustic echo cancellation
-                    // Automatic gain control (AGC)
-                    // bypasses phone mode speech filtering
+                    // Selecting an audio source which does not apply signal processing.
                     .setAudioSource(audioSource)
                     .createAudioDeviceModule();
         }

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -69,6 +69,8 @@
         RCTLogInfo(@"Using video encoder factory: %@", NSStringFromClass([encoderFactory class]));
         RCTLogInfo(@"Using video decoder factory: %@", NSStringFromClass([decoderFactory class]));
 
+        // TODO: We need to change this API and add an extra option that allows disabling voice processing.
+        // Right now this is hardcoded in our custom build.
         _peerConnectionFactory = [[RTCPeerConnectionFactory alloc] initWithEncoderFactory:encoderFactory
                                                                            decoderFactory:decoderFactory
                                                                               audioDevice:audioDevice];

--- a/ios/RCTWebRTC/WebRTCModuleOptions.m
+++ b/ios/RCTWebRTC/WebRTCModuleOptions.m
@@ -21,7 +21,7 @@
         self.fieldTrials = nil;
         self.videoEncoderFactory = nil;
         self.videoDecoderFactory = nil;
-        self.loggingSeverity = RTCLoggingSeverityNone;
+        self.loggingSeverity = RTCLoggingSeverityInfo;
     }
 
     return self;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@daily-co/react-native-webrtc",
-  "version": "124.0.6-daily.1",
+  "version": "124.0.6-daily.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@daily-co/react-native-webrtc",
-      "version": "124.0.6-daily.1",
+      "version": "124.0.6-daily.2",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daily-co/react-native-webrtc",
-  "version": "124.0.6-daily.1",
+  "version": "124.0.6-daily.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/daily-co/react-native-webrtc.git"

--- a/react-native-webrtc.podspec
+++ b/react-native-webrtc.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.libraries           = 'c', 'sqlite3', 'stdc++'
   s.framework           = 'AudioToolbox','AVFoundation', 'CoreAudio', 'CoreGraphics', 'CoreVideo', 'GLKit', 'VideoToolbox'
   s.dependency          'React-Core'
-  s.dependency          'JitsiWebRTC', '~> 124.0.0'
+  s.dependency          'DailyWebRTC', '~> 124.0.0'
 end


### PR DESCRIPTION
- Using a custom Daily WebRTC build with audio processing bypassed on **iOS**.
- Overriding how we build the `JavaAudioDeviceModule` to bypass audio processing on **Android**.