### PR TITLE
Treat USB audio devices as wired headsets

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/DailyAudioDeviceUtils.java
+++ b/android/src/main/java/com/oney/WebRTCModule/DailyAudioDeviceUtils.java
@@ -1,0 +1,20 @@
+package com.oney.WebRTCModule;
+
+import android.media.AudioDeviceInfo;
+
+final class DailyAudioDeviceUtils {
+    private DailyAudioDeviceUtils() {}
+
+    static boolean isWiredHeadsetLikeDevice(AudioDeviceInfo device) {
+        switch (device.getType()) {
+            case AudioDeviceInfo.TYPE_WIRED_HEADSET:
+            case AudioDeviceInfo.TYPE_WIRED_HEADPHONES:
+            case AudioDeviceInfo.TYPE_USB_HEADSET:
+            case AudioDeviceInfo.TYPE_USB_DEVICE:
+            case AudioDeviceInfo.TYPE_USB_ACCESSORY:
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/android/src/main/java/com/oney/WebRTCModule/DailyAudioManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/DailyAudioManager.java
@@ -238,10 +238,7 @@ public class DailyAudioManager implements AudioManager.OnAudioFocusChangeListene
             return AudioDeviceType.BLUETOOTH;
         }
 
-        boolean isWiredHeadsetPlugged = Arrays.stream(audioOutputDevices).anyMatch(
-                device -> device.getType() == AudioDeviceInfo.TYPE_WIRED_HEADSET ||
-                        device.getType() == AudioDeviceInfo.TYPE_WIRED_HEADPHONES
-        );
+        boolean isWiredHeadsetPlugged = Arrays.stream(audioOutputDevices).anyMatch(DailyAudioDeviceUtils::isWiredHeadsetLikeDevice);
         if (isWiredHeadsetPlugged) {
             return AudioDeviceType.WIRED_OR_EARPIECE;
         }

--- a/android/src/main/java/com/oney/WebRTCModule/DailyWebRTCDevicesManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/DailyWebRTCDevicesManager.java
@@ -125,10 +125,7 @@ public class DailyWebRTCDevicesManager {
     private void fillAudioDevices(WritableArray enumerateDevicesArray) {
         AudioDeviceInfo[] audioOutputDevices = this.audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
 
-        boolean isWiredHeadsetPlugged = Arrays.stream(audioOutputDevices).anyMatch(
-                device -> device.getType() == AudioDeviceInfo.TYPE_WIRED_HEADSET ||
-                        device.getType() == AudioDeviceInfo.TYPE_WIRED_HEADPHONES
-        );
+        boolean isWiredHeadsetPlugged = Arrays.stream(audioOutputDevices).anyMatch(DailyAudioDeviceUtils::isWiredHeadsetLikeDevice);
 
         WritableMap params = isWiredHeadsetPlugged ?
                 this.createWritableMap(AudioDeviceType.WIRED_OR_EARPIECE.toString(), "Wired headset", DeviceKind.AUDIO.getKind()) :


### PR DESCRIPTION
## Summary

Treat USB audio output devices as wired-headset-like devices on Android.

USB-C headsets and adapters may be reported as `TYPE_USB_HEADSET`, `TYPE_USB_DEVICE`, or `TYPE_USB_ACCESSORY`. Without recognizing those types, call audio can fall back to speakerphone even when a wired headset is connected.

## Changes

- Add a shared Android audio device helper.
- Use it for both route selection and device enumeration.
